### PR TITLE
Fixes #39, don't run _base.rb for java.rb

### DIFF
--- a/recipes/java.rb
+++ b/recipes/java.rb
@@ -6,9 +6,6 @@
 # Copyright 2014, Rackspace
 #
 
-# base stack requirements
-include_recipe 'elkstack::_base'
-
 # added this for testing. eventually just require wrappers invoke
 # a java cookbook of their choice, or perhaps eventually something that installs
 # java in a 'rackspace way' where customers have accepted the license and


### PR DESCRIPTION
Fixes #39, we don't need _base.rb for a java recipe. We probably could really use a 'rackspace java' cookbook that enables the customers to directly agree to the license and then give us the binaries to install on their systems.
