### PR TITLE
Pass the instance name to custom templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.2.4
 
-- Bump for dev
+- Ensure to pass the instance name to any custom templates, to be sure they end up in the correct directory
 
 # 3.2.3
 

--- a/recipes/logstash.rb
+++ b/recipes/logstash.rb
@@ -65,6 +65,7 @@ node['elkstack']['config']['custom_logstash']['name'].each do |logcfg|
 
   # add one more config for our additional logs
   logstash_custom_config logcfg_name do
+    instance_name instance_name # override the default in case
     service_name instance_name
     template_source_file logcfg_source
     template_source_cookbook logcfg_cookbook


### PR DESCRIPTION
In case the custom templates are rendered by stack_commons with a different logstash instance name than what we expect.
