### PR TITLE
Fixed openssl cookbook, removed bad credentials

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -39,10 +39,6 @@ provisioner:
         enabled: false
       omnibus_updater:
         enabled: false
-    rackspace:
-      cloud_credentials:
-        username: 'racker'
-        api_key: 'sekrit'
     elasticsearch:
       network:
         host: '127.0.0.1'

--- a/Berksfile
+++ b/Berksfile
@@ -26,3 +26,6 @@ group :integration do
   cookbook 'apt'
   cookbook 'yum'
 end
+
+# until https://github.com/opscode-cookbooks/openssl/pull/11
+cookbook 'openssl', git: 'git@github.com:racker/openssl.git'


### PR DESCRIPTION
- Fixed openssl cookbook with https://github.com/opscode-cookbooks/openssl/pull/11, pointing Berkshelf at our copy for now.
- Remove bad cloud creds, they will fail now since elkstack will try to use them for backups
