### PR TITLE
Set Kibana host and port from ElasticSearch attributes

### DIFF
--- a/attributes/kibana.rb
+++ b/attributes/kibana.rb
@@ -7,3 +7,9 @@ default['nginx']['ssl_protocols'] = 'SSLv3 TLSv1 TLSv1.1 TLSv1.2'
 default['nginx']['ssl_cipher_list'] = 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS'
 default['kibana']['nginx']['template_cookbook'] = 'elkstack'
 default['kibana']['nginx']['template'] = 'kibana-nginx.conf.erb'
+
+host = node['elasticsearch']['http']['host']
+default['kibana']['es_server'] = host if host
+
+port = node['elasticsearch']['http']['port']
+default['kibana']['es_port'] = port.to_s if port

--- a/recipes/kibana.rb
+++ b/recipes/kibana.rb
@@ -70,6 +70,7 @@ kibana_web 'kibana' do
   template_cookbook node['kibana']['nginx']['template_cookbook']
   template node['kibana']['nginx']['template']
   es_server node['kibana']['es_server']
+  es_port node['kibana']['es_port']
   not_if { node['kibana']['webserver'].empty? }
 end
 # end replaces 'kibana::install'


### PR DESCRIPTION
This just makes things a little more joined up. The recipe change alone is useful because there is no easy way to change the port number otherwise.
