### PR TITLE
Pin kibana cookbook to the correct ref

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,11 +2,11 @@ source "https://api.berkshelf.com"
 
 metadata
 
-cookbook 'kibana', '~> 1.3', git:'git@github.com:lusis/chef-kibana.git', ref: 'v1.3.2'
+# until https://github.com/lusis/chef-kibana/issues/79
+cookbook 'kibana', git:'git@github.com:racker/chef-kibana.git', branch: 'fix_notifications_martinb3'
 
 # until https://github.com/elasticsearch/cookbook-elasticsearch/pull/230
 cookbook 'elasticsearch', '~> 0.3', git:'git@github.com:racker/cookbook-elasticsearch.git'
-
 # until https://github.com/lusis/chef-logstash/pull/336
 cookbook 'logstash', git:'git@github.com:racker/chef-logstash.git'
 


### PR DESCRIPTION
- With 1.4 being the new HEAD revision in git, the lusis-kibana cookbook was not being found by Berkshelf.
- With kibana's LWRP including nginx recipes directly, remove it from our calls (it will break notifications if the LWRP can't see the resources from nginx)
