### PR TITLE
Fix iptables enable attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ CentOS 6.5
     <td><tt>false</tt></td>
   </tr>
   <tr>
-    <td><tt>['elkstack']['iptables']['enabled']</tt></td>
+    <td><tt>['elkstack']['config']['iptables']</tt></td>
     <td>Boolean</td>
     <td>Enable/Disable iptables functionality</td>
     <td><tt>true</tt></td>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@ default['elkstack']['config']['backups']['enabled'] = true
 default['elkstack']['config']['backups']['cron'] = true
 
 # default to include iptables rules
-default['elkstack']['iptables']['enabled'] = 'true'
+default['elkstack']['config']['iptables'] = true
 
 # default vhost stuff and SSL cert/key name
 default['elkstack']['config']['site_name'] = 'kibana'


### PR DESCRIPTION
The _server.rb file looks for ```['elkstack']['config']['iptables']``` when
deciding whether or not to include the acl recipe. However, the default
attribute being set was ```['elkstack']['iptables']['enabled']```. Updated the
attribute name and the README.

https://github.com/rackspace-cookbooks/elkstack/blob/776cd73a2ade8b3c35f614c069a3b46a2efc9f9b/recipes/_server.rb#L55