### PR TITLE
Add node attribute options for kibana

### DIFF
--- a/recipes/kibana_ssl.rb
+++ b/recipes/kibana_ssl.rb
@@ -17,17 +17,21 @@ directory "#{node['nginx']['dir']}/ssl" do
   recursive true
 end
 
-if node['elkstack'].attribute?('elkstack_kibana_password')
-  basic_auth_password = node['elkstack']['elkstack_kibana_password']
+if node.run_state.key?('elkstack_kibana_password')
+  basic_auth_password = node.run_state['elkstack_kibana_password']
+elsif node.deep_fetch('elkstack', 'config', 'kibana', 'password')
+  basic_auth_password = node.deep_fetch('elkstack', 'config', 'kibana', 'password')
 else
   ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
   basic_auth_password = secure_password
 end
 
-if node['elkstack'].attribute?('elkstack_kibana_username')
-  basic_auth_username = node['elkstack']['elkstack_kibana_username']
+if node.run_state.key?('elkstack_kibana_username')
+  basic_auth_username = node.run_state['elkstack_kibana_username']
+elsif node.deep_fetch('elkstack', 'config', 'kibana', 'username')
+  basic_auth_username = node.deep_fetch('elkstack', 'config', 'kibana', 'username')
 else
-  basic_auth_username = node['elkstack']['config']['kibana']['username']
+  basic_auth_username = 'kibana'
 end
 
 htpasswd "#{node['nginx']['dir']}/htpassword" do

--- a/test/integration/default-nokeypair/serverspec/elasticsearch.rb
+++ b/test/integration/default-nokeypair/serverspec/elasticsearch.rb
@@ -18,7 +18,7 @@ end
 
 describe 'elasticsearch' do
   # test with curl here
-  describe command('sleep 5 && curl localhost:9200/_cluster/health?pretty=1') do
+  describe command('sleep 60 && curl localhost:9200/_cluster/health?pretty=1') do
     its(:stdout) { should match(/.*"status" : "green".*/) }
   end
 

--- a/test/integration/default/serverspec/elasticsearch.rb
+++ b/test/integration/default/serverspec/elasticsearch.rb
@@ -18,7 +18,7 @@ end
 
 describe 'elasticsearch' do
   # test with curl here
-  describe command('sleep 5 && curl localhost:9200/_cluster/health?pretty=1') do
+  describe command('sleep 60 && curl localhost:9200/_cluster/health?pretty=1') do
     its(:stdout) { should match(/.*"status" : "green".*/) }
   end
 


### PR DESCRIPTION
This allows us to consult `node.run_state`, fall back to `node[...]` attributes, and finally use a random password. This is a bit more flexible than before.