### PR TITLE
Update kibana configuration and elasticsearch version

### DIFF
--- a/attributes/elasticsearch.rb
+++ b/attributes/elasticsearch.rb
@@ -3,8 +3,8 @@
 # default['elasticsearch']['version']       = '1.3.4'
 # default['elasticsearch']['rpm_url']       = 'https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.3.4.noarch.rpm'
 # default['elasticsearch']['rpm_sha']       = 'a84034d07196e58b0471c3fe30289a738715c664'
-default['elasticsearch']['version'] = '1.4.3'
-default['elasticsearch']['rpm_url'] = 'https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.3.noarch.rpm'
+default['elasticsearch']['version'] = '1.4.4'
+default['elasticsearch']['rpm_url'] = 'https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.4.noarch.rpm'
 default['elasticsearch']['rpm_sha'] = 'a4b31e6129f4c60bfe0998ede887d0c51a6ab403'
 
 default['elasticsearch']['filename']      = "elasticsearch-#{node['elasticsearch']['version']}.tar.gz"

--- a/templates/default/kibana.yml.erb
+++ b/templates/default/kibana.yml.erb
@@ -1,5 +1,5 @@
 port: <%= @port %>
-elasticsearch: "<%= @elasticsearch %>"
+elasticsearch_url: "<%= @elasticsearch %>"
 host: "0.0.0.0"
 request_timeout: 60
 shard_timeout: 30000
@@ -11,7 +11,7 @@ apps:
 - { id: "visualize", name: "Visualize" }
 - { id: "dashboard", name: "Dashboard" }
 - { id: "settings", name: "Settings" }
-bundledPluginIds:
+bundled_plugin_ids:
  - plugins/dashboard/index
  - plugins/discover/index
  - plugins/settings/index


### PR DESCRIPTION
In order for Kibana 4 to work, 2 parameters needed to be renamed in kibana.yml template and the minimum version of elasticsearch is now 1.4.4