### PR TITLE
Remove lumberjack from default logstash install.

### DIFF
--- a/recipes/logstash.rb
+++ b/recipes/logstash.rb
@@ -34,19 +34,10 @@ my_templates = {
 }
 
 template_variables = {
-  input_lumberjack_host: '0.0.0.0',
-  input_lumberjack_port: 5960,
   input_syslog_host: '0.0.0.0',
   input_syslog_port: 5959,
   chef_environment: node.chef_environment
 }
-
-include_recipe 'elkstack::_secrets'
-unless node.run_state['lumberjack_decoded_certificate'].nil? || node.run_state['lumberjack_decoded_certificate'].nil?
-  my_templates['input_lumberjack'] = 'logstash/input_lumberjack.conf.erb'
-  template_variables['input_lumberjack_ssl_certificate'] = "#{node['logstash']['instance_default']['basedir']}/lumberjack.crt"
-  template_variables['input_lumberjack_ssl_key'] = "#{node['logstash']['instance_default']['basedir']}/lumberjack.key"
-end
 
 logstash_config instance_name do
   action 'create'


### PR DESCRIPTION
Remove lumberjack forwarder parts from default logstash install. This code is duplicated in forwarder.rb where, as I understand it, it is actually supposed to be.
This also removes the annoying dependency on the lumberjack data bag, even if lumberjack is not used.