### PR TITLE
Allow lumberjack functionality to be disabled

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -75,6 +75,21 @@ suites:
           zen:
             minimum_master_nodes: 1 # since search returns more than one, but they are fake
 
+  - name: lumberjack # server with lumberjack disabled
+    data_bags_path: "test/integration/default/data_bags"
+    encrypted_data_bag_secret_key_path: "test/integration/default/encrypted_data_bag_secret"
+    run_list:
+      - recipe[elkstack::java]
+      - recipe[elkstack::cluster] # not testing single, it's practically the same
+    attributes:
+      elkstack:
+        config:
+          lumberjack_data_bag: false
+      elasticsearch:
+        discovery:
+          zen:
+            minimum_master_nodes: 1 # since search returns more than one, but they are fake
+
   - name: agent
     data_bags_path: "test/integration/agent/data_bags"
     encrypted_data_bag_secret_key_path: "test/integration/agent/encrypted_data_bag_secret"

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This key and certificate data should be placed in data bag with name
 `certificate` keys, and base64 encoded into a single line string. You may also
 supply these secrets with some other method and populate the appropriate
 `node.run_state` values (see `_secrets.rb` for more details). Note that this is
-not a PKI trust model, but an [explicit trust model](https://spaces.internet2.edu/display/InCFederation/Metadata+Trust+Models#MetadataTrustModels-ExplicitKeyTrustModel).
+not a PKI trust model, but an [explicit trust model](https://spaces.internet2.edu/display/InCFederation/Metadata+Trust+Models#MetadataTrustModels-ExplicitKeyTrustModel). You may also set the data bag key to false to disable lumberjack entirely.
 
 There exists a make-lumberjack-key.sh to help you make this. For Go 1.3+, you may be required
 by the standard libraries to create a SAN cert [as described here](https://github.com/elasticsearch/logstash-forwarder/issues/221#issuecomment-48823952).

--- a/recipes/_secrets.rb
+++ b/recipes/_secrets.rb
@@ -9,6 +9,11 @@
 # if there's a data bag, get the contents out, shove them in node.run_state
 lumberjack_data_bag = node['elkstack']['config']['lumberjack_data_bag']
 
+unless lumberjack_data_bag
+  Chef::Log.warn("node['elkstack']['config']['lumberjack_data_bag'] was set to false. Not configuring lumberjack or secrets.")
+  return
+end
+
 # try an encrypted data bag first
 lumberjack_secrets = nil
 begin


### PR DESCRIPTION
Per #105, if you set lumberjack_data_bag to false, it will be disabled entirely.