### PR TITLE
Small README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ search criteria.
 Most of this is configurable using the upstream Elasticsearch cookbook's
 attributes, including the chef search itself. There is not an easy toggle to
 turn off the search, however.
-Enables iptables rules if default['elkstack']['iptables']['enabled'] not nil
+Enables iptables rules if `node['elkstack']['iptables']['enabled']` is not `nil`.
 
 ### elkstack::logstash
 


### PR DESCRIPTION
While reading `README.md` I noticed one sentence that did not follow the formatting applied to the rest of the document. Also, it referenced the `default` variable, rather than `node`. 