### PR TITLE
Replace git:// with https:// for forwarder

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,7 +2,7 @@ source "https://api.berkshelf.com"
 
 metadata
 
-# until https://github.com/elasticsearch/cookbook-elasticsearch/pull/230
+# until https://github.com/elastic/cookbook-elasticsearch/pull/230
 cookbook 'elasticsearch', '~> 0.3', git:'git@github.com:racker/cookbook-elasticsearch.git'
 
 # until https://github.com/poise/python/pull/120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ Workarounds and more support for Kibana 4
 
 # 2.0.0
 
-- Add a `forwarder.rb` recipe that installs [logstash-forwarder](https://github.com/elasticsearch/logstash-forwarder) as an alternative to logstash as an agent, including unit and integration tests.
+- Add a `forwarder.rb` recipe that installs [logstash-forwarder](https://github.com/elastic/logstash-forwarder) as an alternative to logstash as an agent, including unit and integration tests.
 - Add additional tests for existing test-kitchen suites to ensure new lumberjack keypair is written to disk.
 - Fix a chefspec test issue where tests were checking for something that didn't make sense, didn't pass.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ supply these secrets with some other method and populate the appropriate
 not a PKI trust model, but an [explicit trust model](https://spaces.internet2.edu/display/InCFederation/Metadata+Trust+Models#MetadataTrustModels-ExplicitKeyTrustModel). You may also set the data bag key to false to disable lumberjack entirely.
 
 There exists a make-lumberjack-key.sh to help you make this. For Go 1.3+, you may be required
-by the standard libraries to create a SAN cert [as described here](https://github.com/elasticsearch/logstash-forwarder/issues/221#issuecomment-48823952).
+by the standard libraries to create a SAN cert [as described here](https://github.com/elastic/logstash-forwarder/issues/221#issuecomment-48823952).
 
 ## [Changelog](CHANGELOG.md)
 

--- a/attributes/forwarder.rb
+++ b/attributes/forwarder.rb
@@ -4,7 +4,7 @@ default['logstash_forwarder']['user'] = 'root'
 default['logstash_forwarder']['group'] = 'root'
 
 default['logstash_forwarder']['app_dir'] = '/opt/logstash-forwarder'
-default['logstash_forwarder']['git_repo'] = 'git://github.com/elasticsearch/logstash-forwarder'
+default['logstash_forwarder']['git_repo'] = 'https://github.com/elastic/logstash-forwarder.git'
 default['logstash_forwarder']['git_revision'] = 'v0.3.1'
 
 default['logstash_forwarder']['config']['network']['servers'] = []

--- a/attributes/kibana.rb
+++ b/attributes/kibana.rb
@@ -10,7 +10,7 @@ default['nginx']['ssl_protocols'] = 'SSLv3 TLSv1 TLSv1.1 TLSv1.2'
 default['nginx']['ssl_cipher_list'] = 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS'
 default['kibana']['nginx']['template_cookbook'] = 'elkstack'
 default['kibana']['nginx']['template'] = 'kibana-nginx.conf.erb'
-default['kibana']['config']['request_timeout'] = 300000
+default['kibana']['config']['request_timeout'] = 300_000
 default['kibana']['config']['shard_timeout'] = 0
 
 host = node['elasticsearch']['http']['host']


### PR DESCRIPTION
- Replace git with http url for forwarder downloads
- Update docs to reflect new elastic org in github (was elasticsearch)