### PR TITLE
Move lumberjack secrets to /etc

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -81,6 +81,4 @@ suites:
     data_bags_path: "test/integration/forwarder/data_bags"
     encrypted_data_bag_secret_key_path: "test/integration/forwarder/encrypted_data_bag_secret"
     run_list:
-      - recipe[java::default]
-      - recipe[elkstack::default]
       - recipe[elkstack::forwarder]

--- a/attributes/forwarder.rb
+++ b/attributes/forwarder.rb
@@ -4,9 +4,9 @@ default['logstash_forwarder']['user'] = 'root'
 default['logstash_forwarder']['group'] = 'root'
 
 default['logstash_forwarder']['config']['network']['servers'] = []
-default['logstash_forwarder']['config']['network']['ssl certificate'] = './logstash-forwarder.crt'
-default['logstash_forwarder']['config']['network']['ssl key'] = './logstash-forwarder.key'
-default['logstash_forwarder']['config']['network']['ssl ca'] = './logstash-forwarder.crt'
+default['logstash_forwarder']['config']['network']['ssl certificate'] = '/etc/lumberjack.crt'
+default['logstash_forwarder']['config']['network']['ssl key'] = '/etc/lumberjack.key'
+default['logstash_forwarder']['config']['network']['ssl ca'] = '/etc/lumberjack.crt'
 default['logstash_forwarder']['config']['network']['timeout'] = 15
 
 # we could glob for these patterns, e.g. "/var/log/*.log", but it picks up some of our non-syslog formatted stuff if we do

--- a/recipes/_lumberjack_secrets.rb
+++ b/recipes/_lumberjack_secrets.rb
@@ -47,25 +47,20 @@ else
   Chef::Log.warn('Unable to complete lumberjack keypair configuration')
 end
 
-logstash_basedir = node.deep_fetch('logstash', 'instance_default', 'basedir')
-attribute_name = "node['logstash']['instance_default']['basedir']"
-err_msg = "#{attribute_name} was not set; please ensure you are using the racker/chef-logstash version until lusis/chef-logstash/pull/336 is merged"
-fail err_msg unless logstash_basedir
-
 # if we had overrode basedir value, we'd need to use the new value here too
-file "#{logstash_basedir}/lumberjack.key" do
+file node['logstash_forwarder']['config']['network']['ssl key'] do
   content node.run_state['lumberjack_decoded_key']
-  owner node['logstash']['instance_default']['user']
-  group node['logstash']['instance_default']['group']
+  owner node['logstash_forwarder']['user']
+  group node['logstash_forwarder']['group']
   mode '0600'
   not_if { node.run_state['lumberjack_decoded_key'].nil? }
 end
 
 # if we had overrode basedir value, we'd need to use the new value here too
-file "#{logstash_basedir}/lumberjack.crt" do
+file node['logstash_forwarder']['config']['network']['ssl certificate'] do
   content node.run_state['lumberjack_decoded_certificate']
-  owner node['logstash']['instance_default']['user']
-  group node['logstash']['instance_default']['group']
+  owner node['logstash_forwarder']['user']
+  group node['logstash_forwarder']['group']
   mode '0600'
   not_if { node.run_state['lumberjack_decoded_certificate'].nil? }
 end

--- a/recipes/forwarder.rb
+++ b/recipes/forwarder.rb
@@ -10,13 +10,6 @@
 include_recipe 'elkstack::_base'
 include_recipe 'chef-sugar'
 
-# override logstash values with forwarder ones, ensure directory exists, for _secrets.rb
-directory node['logstash']['instance_default']['basedir'] do
-  user node['logstash']['instance_default']['user']
-  group node['logstash']['instance_default']['group']
-  mode 0755
-end
-
 # find central servers and configure appropriately
 include_recipe 'elasticsearch::search_discovery'
 elk_nodes = node['elasticsearch']['discovery']['zen']['ping']['unicast']['hosts']
@@ -30,9 +23,9 @@ node.set['logstash_forwarder']['config']['network']['servers'] = forwarder_serve
 
 include_recipe 'elkstack::_lumberjack_secrets'
 unless node.run_state['lumberjack_decoded_certificate'].nil? || node.run_state['lumberjack_decoded_certificate'].nil?
-  node.set['logstash_forwarder']['config']['network']['ssl certificate'] = "#{node['logstash']['instance_default']['basedir']}/lumberjack.crt"
-  node.set['logstash_forwarder']['config']['network']['ssl key'] = "#{node['logstash']['instance_default']['basedir']}/lumberjack.key"
-  node.set['logstash_forwarder']['config']['network']['ssl ca'] = "#{node['logstash']['instance_default']['basedir']}/lumberjack.crt"
+  node.set['logstash_forwarder']['config']['network']['ssl certificate'] = '/etc/lumberjack.crt'
+  node.set['logstash_forwarder']['config']['network']['ssl key'] = '/etc/lumberjack.key'
+  node.set['logstash_forwarder']['config']['network']['ssl ca'] = '/etc/lumberjack.crt'
 end
 
 case node['platform_family']

--- a/test/integration/forwarder/serverspec/default_spec.rb
+++ b/test/integration/forwarder/serverspec/default_spec.rb
@@ -16,20 +16,20 @@ describe 'logstash-forwarder service' do
 end
 
 describe 'lumberjack keypair' do
-  describe file('/opt/logstash/lumberjack.crt') do
+  describe file('/etc/lumberjack.crt') do
     it { should be_file }
   end
 
-  describe file('/opt/logstash/lumberjack.key') do
+  describe file('/etc/lumberjack.key') do
     it { should be_file }
   end
 end
 
 describe file('/etc/logstash-forwarder') do
   it { should be_file }
-  it { should contain '"ssl certificate": "/opt/logstash/lumberjack.crt"' }
-  it { should contain '"ssl key": "/opt/logstash/lumberjack.key"' }
-  it { should contain '"ssl ca": "/opt/logstash/lumberjack.crt"' }
+  it { should contain '"ssl certificate": "/etc/lumberjack.crt"' }
+  it { should contain '"ssl key": "/etc/lumberjack.key"' }
+  it { should contain '"ssl ca": "/etc/lumberjack.crt"' }
 
   it { should contain '"1.2.3.4:5960"' }
   it { should contain '"1.2.3.5:5960"' }

--- a/test/unit/spec/agent_nokeypair.rb
+++ b/test/unit/spec/agent_nokeypair.rb
@@ -21,7 +21,7 @@ describe 'elkstack::agent' do
   end
 
   it 'creates lumberjack keypairs when no data bags exist' do
-    expect(chef_run).to create_file('/opt/logstash/lumberjack.key')
-    expect(chef_run).to create_file('/opt/logstash/lumberjack.crt')
+    expect(chef_run).to_not create_file('/etc/lumberjack.key')
+    expect(chef_run).to_not create_file('/etc/lumberjack.crt')
   end
 end

--- a/test/unit/spec/agent_spec.rb
+++ b/test/unit/spec/agent_spec.rb
@@ -33,8 +33,8 @@ describe 'elkstack::agent' do
   end
 
   it 'creates lumberjack key and certificate files' do
-    expect(chef_run).to create_file('/opt/logstash/lumberjack.key')
-    expect(chef_run).to create_file('/opt/logstash/lumberjack.crt')
+    expect(chef_run).to create_file('/etc/lumberjack.key')
+    expect(chef_run).to create_file('/etc/lumberjack.crt')
   end
 end
 

--- a/test/unit/spec/elasticsearch_nokeypair.rb
+++ b/test/unit/spec/elasticsearch_nokeypair.rb
@@ -20,7 +20,7 @@ describe 'elkstack::default' do
   end
 
   it 'creates lumberjack keypairs when no data bags exist' do
-    expect(chef_run).to create_file('/opt/logstash/lumberjack.key')
-    expect(chef_run).to create_file('/opt/logstash/lumberjack.crt')
+    expect(chef_run).to_not create_file('/etc/lumberjack.key')
+    expect(chef_run).to_not create_file('/etc/lumberjack.crt')
   end
 end

--- a/test/unit/spec/forwarder_spec.rb
+++ b/test/unit/spec/forwarder_spec.rb
@@ -22,15 +22,17 @@ describe 'elkstack::forwarder' do
   it 'create service for the forwarder' do
     expect(chef_run).to enable_service('logstash-forwarder')
     expect(chef_run).to start_service('logstash-forwarder')
+    expect(chef_run).to render_file('/etc/init.d/logstash-forwarder')
   end
 
   it 'creates lumberjack key and certificate files' do
-    expect(chef_run).to create_file('/opt/logstash/lumberjack.key')
-    expect(chef_run).to create_file('/opt/logstash/lumberjack.crt')
+    expect(chef_run).to create_file('/etc/lumberjack.key')
+    expect(chef_run).to create_file('/etc/lumberjack.crt')
   end
 
   it 'installs logstash-forwarder pkg' do
     expect(chef_run).to install_package('logstash-forwarder')
+    expect(chef_run).to add_apt_repository('logstash-forwarder')
   end
 
   it 'creates logstash-forwarder configuration file' do


### PR DESCRIPTION
This will avoid the conflict with /opt/logstash being used for secrets storage. We were sometimes making that owned by root, sometimes by the logstash user. When no logstash user was present, convergence failed. RE: #143.