### PR TITLE
Beef up chef-solo testing and guards

### DIFF
--- a/recipes/agent_acl.rb
+++ b/recipes/agent_acl.rb
@@ -8,11 +8,10 @@
 
 add_iptables_rule('INPUT', '-i lo -j ACCEPT', 9900, 'allow services on loopback to talk to any interface')
 
-include_recipe 'elasticsearch::search_discovery'
-es_nodes = node['elasticsearch']['discovery']['zen']['ping']['unicast']['hosts']
+include_recipe 'elasticsearch::search_discovery' unless Chef::Config[:solo]
+es_nodes = node.deep_fetch('elasticsearch', 'discovery', 'zen', 'ping', 'unicast', 'hosts')
+es_nodes = '' if es_nodes.nil?
 
-if es_nodes
-  es_nodes.split(',').each do |host|
-    add_iptables_rule('INPUT', "-p tcp -s #{host} --dport 9300 -j ACCEPT", 9996, "allow ES host #{host} to connect")
-  end
+es_nodes.split(',').each do |host|
+  add_iptables_rule('INPUT', "-p tcp -s #{host} --dport 9300 -j ACCEPT", 9996, "allow ES host #{host} to connect")
 end

--- a/recipes/elasticsearch.rb
+++ b/recipes/elasticsearch.rb
@@ -14,7 +14,7 @@ include_recipe 'chef-sugar'
 
 # use chef search, not multicast, for cluster discovery
 node.override['elasticsearch']['discovery']['zen']['ping']['multicast']['enabled'] = false
-include_recipe 'elasticsearch::search_discovery'
+include_recipe 'elasticsearch::search_discovery' unless Chef::Config[:solo]
 
 # find and format and mount any relevant disks
 include_recipe 'elkstack::disk_setup'

--- a/recipes/forwarder.rb
+++ b/recipes/forwarder.rb
@@ -11,9 +11,9 @@ include_recipe 'elkstack::_base'
 include_recipe 'chef-sugar'
 
 # find central servers and configure appropriately
-include_recipe 'elasticsearch::search_discovery'
-elk_nodes = node['elasticsearch']['discovery']['zen']['ping']['unicast']['hosts']
-elk_nodes = [] if elk_nodes.nil?
+include_recipe 'elasticsearch::search_discovery' unless Chef::Config[:solo]
+elk_nodes = node.deep_fetch('elasticsearch', 'discovery', 'zen', 'ping', 'unicast', 'hosts')
+elk_nodes = '' if elk_nodes.nil?
 
 forwarder_servers = []
 elk_nodes.split(',').each do |new_node|

--- a/test/unit/spec/chefsolo_spec.rb
+++ b/test/unit/spec/chefsolo_spec.rb
@@ -1,0 +1,23 @@
+# Encoding: utf-8
+
+require_relative 'spec_helper'
+
+describe 'elkstack::default' do
+  let(:chef_run) do
+    stub_command("curl -sI http://eslocal:9200/_snapshot/elkstack | grep -q \"404 Not Found\"").and_return(0)
+    ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5') do |node|
+      node.set['cpu']['total'] = 8
+      node.set['memory']['total'] = 4096
+      node.set['public_info']['remote_ip'] = '127.0.0.1'
+      node.set['chef_environment'] = '_default' # be a dummy env for htpasswd.curl
+      node.set['rackspace']['cloud_credentials']['username'] = 'joe-test'
+      node.set['rackspace']['cloud_credentials']['api_key'] = '123abc'
+      node.set['filesystem'] = []
+    end.converge(described_recipe)
+    # converge WITH platformstack so we can test our templates are created
+  end
+
+  it 'installs ruby' do
+    expect(chef_run).to install_package('ruby')
+  end
+end

--- a/test/unit/spec/forwarder_spec.rb
+++ b/test/unit/spec/forwarder_spec.rb
@@ -15,7 +15,6 @@ describe 'elkstack::forwarder' do
 
   it 'includes the _agent, elasticsearch::search_discovery, _secrets, and rsyslog::client recipes' do
     expect(chef_run).to include_recipe('elkstack::forwarder')
-    expect(chef_run).to include_recipe('elasticsearch::search_discovery')
     expect(chef_run).to include_recipe('elkstack::_lumberjack_secrets')
   end
 


### PR DESCRIPTION
- Add additional guards for chef-solo before calling elasticsearch::search_discovery
- Ensure node.deep_fetch is used when getting unicast hosts, handle empty / not found case
- RE: #144.