### PR TITLE
Remove stack commons dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -24,3 +24,6 @@ depends 'rsyslog'
 depends 'runit'
 depends 'stack_commons', '>= 0.0.39'
 depends 'yum'
+
+# Pinned down poise waiting for https://github.com/lusis/chef-kibana/pull/91
+depends 'poise', '~> 1.0.12'

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,9 +20,9 @@ depends 'openssl'
 depends 'newrelic_meetme_plugin'
 depends 'nginx'
 depends 'platformstack'
+depends 'python'
 depends 'rsyslog'
 depends 'runit'
-depends 'stack_commons', '>= 0.0.39'
 depends 'yum'
 
 # Pinned down poise waiting for https://github.com/lusis/chef-kibana/pull/91

--- a/recipes/_base.rb
+++ b/recipes/_base.rb
@@ -14,5 +14,5 @@ include_recipe 'build-essential'
 
 include_recipe 'chef-sugar'
 
-# everybody loves python! (this is a shortening of python::default)
-include_recipe 'stack_commons::python'
+# everybody loves python! (this is a shortening(with fix) of python::default)
+include_recipe 'elkstack::_python'

--- a/recipes/_python.rb
+++ b/recipes/_python.rb
@@ -1,0 +1,39 @@
+# Encoding: utf-8
+#
+# Cookbook Name:: elkstack
+# Recipe:: _python
+#
+# Copyright 2014, Rackspace Hosting
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Upgrade pip once and setuptools twice to ensure pip works -- (the three
+# include_recipes below map to python::default, with our install interjected
+# into the middle)
+
+include_recipe 'chef-sugar'
+
+include_recipe "python::#{node['python']['install_method']}"
+include_recipe 'python::pip'
+
+bash 'manually upgrade setuptools' do
+  user 'root'
+  cwd '/tmp'
+  code <<-EOH
+  easy_install --upgrade setuptools
+  EOH
+  only_if { rhel? }
+end
+
+include_recipe 'python::virtualenv'

--- a/recipes/newrelic.rb
+++ b/recipes/newrelic.rb
@@ -23,6 +23,6 @@ unless node['newrelic']['license'].nil?
 
   user node['newrelic_meetme_plugin']['user']
 
-  include_recipe 'stack_commons::python'
+  include_recipe 'elkstack::_python'
   include_recipe 'newrelic_meetme_plugin'
 end

--- a/test/fixtures/cookbooks/wrapper/metadata.rb
+++ b/test/fixtures/cookbooks/wrapper/metadata.rb
@@ -5,5 +5,3 @@ license          'Apache 2.0'
 description      'Installs/Configures wrapper for test-kitchen tests'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
-
-depends 'stack_commons'


### PR DESCRIPTION
I've just copied the stack_commons::python recipe for now.
It's adding duplication but remove all the dependencies on stack_commons (faster, less conflict).

I've pinned down poise for now because it's been 10 days since @martinb3 submitted https://github.com/lusis/chef-kibana/pull/91, and it's blocking all the ELKstack PRs