### PR TITLE
remove stdout as default log config

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -1,4 +1,14 @@
 agent_name = node['elkstack']['config']['logstash']['agent_name']
+
+default['elkstack']['config']['logstash']['agent']['my_templates'] = {
+  'input_syslog'         => 'logstash/input_syslog.conf.erb'
+}
+
+# node.default['elkstack']['config']['logstash']['my_templates'] = {
+#   'input_syslog'         => 'logstash/input_syslog.conf.erb',
+#   'output_stdout'        => 'logstash/output_stdout.conf.erb'
+# }
+
 agent = normal['logstash']['instance'][agent_name]
 
 agent['bind_host_interface'] = '127.0.0.1'

--- a/attributes/logstash.rb
+++ b/attributes/logstash.rb
@@ -30,6 +30,16 @@ server['pattern_templates_cookbook'] = 'logstash'
 server['base_config_cookbook'] = 'logstash'
 server['config_templates_cookbook'] = 'logstash'
 
+# templates
+# by default, these are the inputs and outputs on the server
+# we receive anything from any protocol we might know about
+default['elkstack']['config']['logstash']['server']['my_templates'] = {
+  'input_syslog'         => 'logstash/input_syslog.conf.erb',
+  'input_tcp'            => 'logstash/input_tcp.conf.erb',
+  'input_udp'            => 'logstash/input_udp.conf.erb',
+  'output_elasticsearch' => 'logstash/output_elasticsearch.conf.erb'
+}
+
 # variables for templates
 config_templates_variables = {}
 config_templates_variables['elasticsearch_embedded'] = server['enable_embedded_es']

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -40,11 +40,6 @@ logstash_service agent_name do
   retry_delay 5
 end
 
-my_templates = {
-  'input_syslog'         => 'logstash/input_syslog.conf.erb',
-  'output_stdout'        => 'logstash/output_stdout.conf.erb'
-}
-
 template_variables = {
   output_lumberjack_hosts: elk_nodes.split(','),
   output_lumberjack_port: 5960,
@@ -67,9 +62,8 @@ lumberjack_keypair = node.run_state['lumberjack_decoded_key'] && node.run_state[
 # default is 'tcp_udp'
 if node['elkstack']['config']['agent_protocol'] == 'tcp_udp'
   # TODO: udp and tcp senders
-
-  my_templates['output_tcp'] = 'logstash/output_tcp.conf.erb'
-  my_templates['output_udp'] = 'logstash/output_udp.conf.erb'
+  node.default['elkstack']['config']['logstash']['agent']['my_templates']['output_tcp'] = 'logstash/output_tcp.conf.erb'
+  node.default['elkstack']['config']['logstash']['agent']['my_templates']['output_udp'] = 'logstash/output_tcp.conf.erb'
 
   template_variables[:output_tcp_host] = elk_nodes.split(',').first
   template_variables[:output_tcp_port] = 5961
@@ -78,7 +72,7 @@ if node['elkstack']['config']['agent_protocol'] == 'tcp_udp'
 
 # if flag is set *and* key & cert are available
 elsif node['elkstack']['config']['agent_protocol'] == 'lumberjack' && lumberjack_keypair
-  my_templates['output_lumberjack'] = 'logstash/output_lumberjack.conf.erb'
+  node.default['elkstack']['config']['logstash']['agent']['my_templates']['output_lumberjack'] = 'logstash/output_lumberjack.conf.erb'
   template_variables['output_lumberjack_ssl_certificate'] = "#{node['logstash']['instance_default']['basedir']}/lumberjack.crt"
   # template_variables['output_lumberjack_ssl_key'] = "#{node['logstash']['instance_default']['basedir']}/lumberjack.key"
 end
@@ -90,7 +84,7 @@ end
 
 logstash_config agent_name do
   templates_cookbook 'elkstack'
-  templates my_templates
+  templates node['elkstack']['config']['logstash']['agent']['my_templates']
   variables(template_variables)
   notifies :restart, "logstash_service[#{agent_name}]", :delayed
   action [:create]

--- a/recipes/kibana.rb
+++ b/recipes/kibana.rb
@@ -99,6 +99,7 @@ kibana_web 'kibana' do
   es_port node['kibana']['es_port']
   server_name node['kibana']['server_name']
   server_aliases node['kibana']['server_aliases']
+  action :create
   not_if { node['kibana']['webserver'] == '' }
 end
 # end replaces 'kibana::install'

--- a/recipes/logstash.rb
+++ b/recipes/logstash.rb
@@ -26,16 +26,6 @@ directory node['logstash']['instance_default']['basedir'] do
   mode '0755'
 end
 
-# by default, these are the inputs and outputs on the server
-# we receive anything from any protocol we might know about
-my_templates = {
-  'input_syslog'         => 'logstash/input_syslog.conf.erb',
-  'input_tcp'            => 'logstash/input_tcp.conf.erb',
-  'input_udp'            => 'logstash/input_udp.conf.erb',
-  'output_stdout'        => 'logstash/output_stdout.conf.erb',
-  'output_elasticsearch' => 'logstash/output_elasticsearch.conf.erb'
-}
-
 template_variables = {
   input_lumberjack_host: '0.0.0.0',
   input_lumberjack_port: 5960,
@@ -59,7 +49,7 @@ node.default['lumberjack']['group'] = node['logstash']['instance_default']['grou
 include_recipe 'elkstack::_lumberjack_secrets'
 unless node.run_state['lumberjack_decoded_certificate'].nil? || node.run_state['lumberjack_decoded_certificate'].nil?\
  || node['elkstack']['config']['agent_protocol'] != 'lumberjack'
-  my_templates['input_lumberjack'] = 'logstash/input_lumberjack.conf.erb'
+  node.default['elkstack']['config']['logstash']['server']['my_templates']['input_lumberjack'] = 'logstash/input_lumberjack.conf.erb'
   template_variables['input_lumberjack_ssl_certificate'] = node['lumberjack']['ssl_cert_path']
   template_variables['input_lumberjack_ssl_key'] = node['lumberjack']['ssl_key_path']
 end
@@ -67,7 +57,7 @@ end
 logstash_config instance_name do
   action 'create'
   templates_cookbook 'elkstack'
-  templates my_templates
+  templates node['elkstack']['config']['logstash']['server']['my_templates']
   variables(template_variables)
   notifies :restart, "logstash_service[#{instance_name}]", :delayed
 end

--- a/test/integration/default/serverspec/elasticsearch.rb
+++ b/test/integration/default/serverspec/elasticsearch.rb
@@ -38,6 +38,11 @@ describe 'elasticsearch' do
     its(:stdout) { should match(/.*"status" : "green".*/) }
   end
 
+  # time to obey the previous command
+  describe command('sleep 10') do
+    its(:exit_status) { should eq 0 }
+  end
+
   # can't use process() matcher because of two java processes
   describe command('ps aux | grep -v grep | grep -si org.elasticsearch.bootstrap.Elasticsearch') do
     its(:exit_status) { should eq 0 }


### PR DESCRIPTION
This is to prevet an issue with large stdout spam/logs being reported.
Need to remove stdout as default and make templates an overridable attribute rather than hardcoded