### PR TITLE
Rename centos test-kitchen platform

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -54,7 +54,7 @@ platforms:
   - name: ubuntu-12.04
     run_list:
     - recipe[apt]
-  - name: centos-6.6
+  - name: centos-6
     run_list:
     - recipe[yum]
 


### PR DESCRIPTION
CentOS minor version floats:
https://unix.stackexchange.com/questions/60660/minor-upgrades-and-version-numbers-on-centos

More consistent to just call it centos-6. (For example, providers like DigitalOcean offer images of 6.5)