### PR TITLE
set default to openjdk 8 to avoid java ssl problem

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -57,6 +57,10 @@ platforms:
   - name: centos-6.6
     run_list:
     - recipe[yum]
+    attributes:
+      java:
+        jdk_version: 8
+
 
 suites:
   - name: default # server


### PR DESCRIPTION
Problem: 
* The `default` test fails to converge on CentOS 6.6.
* Appears this is related to [this Java problem](http://blog.backslasher.net/java-ssl-crash.html).

Proposed Solution:
* Set OpenJDK version to 8 for CentOS 6.6 platform.

Now, successfully converges `default-centos-66`.
