### PR TITLE
Add missing SSL attributes to nginx config

### DIFF
--- a/attributes/kibana.rb
+++ b/attributes/kibana.rb
@@ -1,13 +1,13 @@
 default['kibana']['web_dir'] = '/opt/kibana/current'
 default['kibana']['webserver_port'] = 443
 default['kibana']['webserver_scheme'] = 'https://'
-default['nginx']['disable_http'] = true
+default['nginx']['disable_http'] = false
 default['nginx']['ssl_key'] = '/etc/nginx/ssl/kibana.key'
 default['nginx']['ssl_cert'] = '/etc/nginx/ssl/kibana.pem'
 default['nginx']['ssl_protocols'] = 'TLSv1.1 TLSv1.2'
 default['nginx']['ssl_cipher_list'] = 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH'
 default['nginx']['ssl_prefer_server_ciphers'] = 'on'
-default['nginx']['use_dhparam'] = true
+default['nginx']['use_dhparam'] = false
 default['nginx']['ssl_dhparam'] = '/etc/nginx/ssl/dhparam.pem'
 default['nginx']['ssl_dhparam_bits'] = 2048
 

--- a/attributes/kibana.rb
+++ b/attributes/kibana.rb
@@ -1,10 +1,13 @@
 default['kibana']['web_dir'] = '/opt/kibana/current'
 default['kibana']['webserver_port'] = 443
 default['kibana']['webserver_scheme'] = 'https://'
+default['nginx']['disable_http'] = true
 default['nginx']['ssl_key'] = '/etc/nginx/ssl/kibana.key'
 default['nginx']['ssl_cert'] = '/etc/nginx/ssl/kibana.pem'
-default['nginx']['ssl_protocols'] = 'TLSv1 TLSv1.1 TLSv1.2'
+default['nginx']['ssl_protocols'] = 'TLSv1.1 TLSv1.2'
 default['nginx']['ssl_cipher_list'] = 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH'
+default['nginx']['ssl_prefer_server_ciphers'] = 'on'
+
 default['kibana']['nginx']['template_cookbook'] = 'elkstack'
 default['kibana']['nginx']['template'] = 'kibana-nginx.conf.erb'
 default['kibana']['config']['request_timeout'] = 300_000

--- a/attributes/kibana.rb
+++ b/attributes/kibana.rb
@@ -7,6 +7,9 @@ default['nginx']['ssl_cert'] = '/etc/nginx/ssl/kibana.pem'
 default['nginx']['ssl_protocols'] = 'TLSv1.1 TLSv1.2'
 default['nginx']['ssl_cipher_list'] = 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH'
 default['nginx']['ssl_prefer_server_ciphers'] = 'on'
+default['nginx']['use_dhparam'] = true
+default['nginx']['ssl_dhparam'] = '/etc/nginx/ssl/dhparam.pem'
+default['nginx']['ssl_dhparam_bits'] = 2048
 
 default['kibana']['nginx']['template_cookbook'] = 'elkstack'
 default['kibana']['nginx']['template'] = 'kibana-nginx.conf.erb'

--- a/recipes/kibana_ssl.rb
+++ b/recipes/kibana_ssl.rb
@@ -61,3 +61,13 @@ openssl_x509 cert_file do
   country 'US'
   key_file key_file
 end
+
+if node['nginx']['use_dhparam']
+  template node['nginx']['ssl_dhparam'] do
+    source 'dhparam.pem.erb'
+    owner 'root'
+    group 'root'
+    mode '0600'
+    action :create_if_missing
+  end
+end

--- a/templates/default/dhparam.pem.erb
+++ b/templates/default/dhparam.pem.erb
@@ -1,0 +1,5 @@
+<%=
+  require 'openssl'
+  Chef::Log.warn("Generating dhparam.pem, this will take a while...")
+  OpenSSL::PKey::DH.new(node['nginx']['ssl_dhparam_bits'], 2)
+-%>

--- a/templates/default/kibana-nginx.conf.erb
+++ b/templates/default/kibana-nginx.conf.erb
@@ -1,5 +1,7 @@
 server {
+<%- unless node['nginx']['disable_http'] -%>
   listen                80;
+<%- end -%>
   listen                443 ssl;
 
   server_name           <%= @server_name %> <%= @server_aliases.join(" ") %>;
@@ -7,12 +9,15 @@ server {
 
   ssl_certificate_key <%= node['nginx']['ssl_key'] %>;
   ssl_certificate <%= node['nginx']['ssl_cert'] %>;
+  ssl_protocols <%= node['nginx']['ssl_protocols'] %>;
+  ssl_ciphers <%= node['nginx']['ssl_cipher_list'] %>;
+  ssl_prefer_server_ciphers <%= node['nginx']['ssl_prefer_server_ciphers'] %>;
 
-  <% if node['elkstack']['config']['kibana']['redirect'] %>
+  <%- if node['elkstack']['config']['kibana']['redirect'] -%>
   if ( $scheme = http ){
     rewrite ^ https://<%= @server_name %>$request_uri? permanent;
   }
-  <% end %>
+  <%- end -%>
 
   location / {
     proxy_pass http://localhost:<%= @kibana_port %>;


### PR DESCRIPTION
Cipher and protocols where defined in attributed, but never passed through to the nginx configuration!

Also, deprecated TLSv1.0 by default