### PR TITLE
replace deprecated define_runner_method with define_matcher

### DIFF
--- a/test/unit/spec/support/matchers.rb
+++ b/test/unit/spec/support/matchers.rb
@@ -1,7 +1,7 @@
 # elkstack/libraries/matchers.rb
 
 if defined?(ChefSpec)
-  # ChefSpec::Runner.define_runner_method(:heat_nginx_vhost)
+  # ChefSpec.define_matcher(:heat_nginx_vhost)
 
   # Logstash matchers
   def create_logstash_service(resource)


### PR DESCRIPTION
```
[DEPRECATION] `ChefSpec::Runner.define_runner_method' is deprecated. It is being used in the logstash_service resource matcher. Please use `ChefSpec.define_matcher' instead. (called from spec/_web_spec.rb:16:in `block (2 levels) in <top (required)>')
```

Trying to resolve the above deprecation warning, taking a stab in the dark (untested).